### PR TITLE
Closes #112. No filter-chooser appear if no fields

### DIFF
--- a/src/js/components/FilterCriteria.jsx
+++ b/src/js/components/FilterCriteria.jsx
@@ -158,6 +158,14 @@ class FilterCriteria extends Component {
       wrapperStyle
     } = this.props
 
+    if (fields.data.length === 0) {
+      return (
+        <div style={wrapperStyle}>
+          <h3>No fields found to use for filtering</h3>
+        </div>
+      )
+    }
+
     return (
       <div style={wrapperStyle}>
         <h3 style={headerStyle}>


### PR DESCRIPTION
If, for some reason, there are no column headers in the data source, no
filtering should be possible.
