### PR TITLE
Closes #179 - add optional header

### DIFF
--- a/default-config.json
+++ b/default-config.json
@@ -6,6 +6,8 @@
   "domain": "localhost",
   "footerLeftText": [],
   "footerRightText": [],
+  "headerStyle": {},
+  "headerText": "",
   "helpMenuItems": [],
   "homeRoute": "Home",
   "hotModuleReloadUri": "localhost",

--- a/src/js/components/App.jsx
+++ b/src/js/components/App.jsx
@@ -5,6 +5,7 @@ import {fetchUser} from '../modules/user'
 import {Footer} from './Footer'
 import getMuiTheme from 'material-ui/styles/getMuiTheme'
 import {GlobalStyles} from './GlobalStyles'
+import {Header} from './Header'
 import {LeftNav} from './LeftNav'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 import {Wrapper} from './Wrapper'
@@ -79,6 +80,7 @@ class App extends Component {
           <LeftNav />
           <Wrapper style={style.wrapper}>
             <Banner />
+            <Header />
             <div style={style.flexWrapper}>
               {children}
             </div>

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import {grey800, white} from 'material-ui/styles/colors'
+import {headerStyle, headerText} from '../../../config'
+
+const style = {
+  header: {
+    background: grey800,
+    color: white,
+    fontSize: '0.8rem',
+    textAlign: 'center',
+    ...headerStyle
+  }
+}
+
+export const Header = () => {
+  if (headerText === null || headerText === '') {
+    return null
+  }
+
+  return (
+    <header style={style.header}>{headerText}</header>
+  )
+}

--- a/src/js/styles/common.js
+++ b/src/js/styles/common.js
@@ -1,4 +1,4 @@
-import {bannerText} from '../../../config'
+import {bannerText, headerText} from '../../../config'
 
 export const header = {
   backgroundColor: '#00bcd4',
@@ -15,6 +15,14 @@ export const verticalTop = {
   verticalAlign: 'top'
 }
 
-export const logoStyle = bannerText
-  ? {padding: '24px 16px'}
-  : {}
+let logoStyle
+
+if (bannerText && headerText) {
+  logoStyle = {padding: '1.98em 1.05em'}
+} else if (bannerText || headerText) {
+  logoStyle = {padding: '1.5em 1.05em'}
+} else {
+  logoStyle = {padding: '1.05em'}
+}
+
+export {logoStyle}


### PR DESCRIPTION
If `headerText` is set, you get a header. If it's blank `''`, no header.

`headerStyle` can be empty `{}` or have settings to override the header's standard formatting. For example:

``` javascript
headerStyle: {
  background: 'black',
  color: 'red', 
  fontSize: '1.5rem'
},
```
